### PR TITLE
Adds publisher verification for py-kube-downscaler on artifacthub

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: f856071a-e6cd-4c16-8678-1523894bdc05


### PR DESCRIPTION
### Issue Reference
This PR addresses the following issue: [Issue #53](https://github.com/caas-team/py-kube-downscaler/issues/53).

### Summary
This PR adds the `artifacthub-repo.yml` file required for distributing the official Helm chart of the `py-kube-downscaler` project through Artifact Hub.

### Changes Made
- **Added `artifacthub-repo.yml` File wih repositoryID as content**

### References
-  https://artifacthub.io/docs/topics/repositories/#:~:text=Please%20note%20that%20the%20artifacthub,repository%20HTTP%20server%20as%20well
- https://moreillon.medium.com/distributing-an-application-as-helm-chart-on-artifact-hub-3347dfe7f0f7